### PR TITLE
Simple refactor

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,0 +1,24 @@
+
+locals {
+
+  vpc_tags = merge(
+    {
+      "Region"      = var.region
+      "Environment" = "core"
+    },
+    var.default_tags,
+    var.kubernetes_tags,
+  )
+
+  features_defaults = {
+    users    = false
+    vpc      = false
+    dns      = false
+    maws     = false
+    infosec  = true
+    account  = true
+    policies = true
+  }
+  features = merge(local.features_defaults, var.features)
+
+}

--- a/main.tf
+++ b/main.tf
@@ -3,34 +3,23 @@ provider "aws" {
   region  = var.region
 }
 
-locals {
-  vpc_tags = merge(
-    {
-      "Region"      = var.region
-      "Environment" = "core"
-    },
-    var.default_tags,
-    var.kubernetes_tags,
-  )
-}
-
 data "aws_caller_identity" "current" {
 }
 
 module "policies" {
   source  = "./modules/policies"
-  enabled = var.features["policies"]
+  enabled = local.features["policies"]
 }
 
 module "account" {
   source       = "./modules/account"
   account_name = var.account_name
-  enabled      = var.features["account"]
+  enabled      = local.features["account"]
 }
 
 module "users" {
   source                       = "./modules/users"
-  create_users                 = var.features["users"]
+  create_users                 = local.features["users"]
   create_access_keys           = var.users["create_access_keys"]
   create_delegated_permissions = var.users["create_delegated_permissions"]
   write_access_files           = var.users["write_access_files"]
@@ -40,12 +29,12 @@ module "users" {
 
 module "maws" {
   source  = "./modules/maws"
-  enabled = var.features["maws"]
+  enabled = local.features["maws"]
 }
 
 module "infosec" {
   source  = "./modules/infosec"
-  enabled = var.features["infosec"]
+  enabled = local.features["infosec"]
 
   cloudtrail_bucket    = var.infosec["bucket"]
   cloudtrail_sns_topic = var.infosec["sns_topic"]
@@ -60,14 +49,14 @@ module "cloudhealth" {
 
 module "dns" {
   source       = "./modules/dns"
-  enabled      = var.features["dns"]
+  enabled      = local.features["dns"]
   account_name = var.account_name
 }
 
 module "vpc" {
   source                   = "./modules/vpc"
   region                   = var.region
-  enable_vpc               = var.features["vpc"]
+  enable_vpc               = local.features["vpc"]
   name                     = var.vpc["name"]
   vpc_cidr                 = var.vpc["vpc_cidr"]
   az_placement             = var.vpc["az_placement"]

--- a/variables.tf
+++ b/variables.tf
@@ -16,15 +16,9 @@ variable "delegated_account_ids" {
 }
 
 variable "features" {
-  default = {
-    users    = false
-    vpc      = false
-    dns      = false
-    maws     = false
-    infosec  = true
-    account  = true
-    policies = true
-  }
+  description = "List of features to enable, look at local.tf for full list of valus"
+  type        = map(string)
+  default     = {}
 }
 
 variable "users" {


### PR DESCRIPTION
Refactor features flag, the previous behaviour if you are looking to
enable a singular feature and leave everything else default the module
will force you to list out all the feature map in `terraform.tfvars`.
With this refactor you no longer need to do that, now if you want to
leave everything default and enable one option out of the feature flag
you just need to create that one specific map value in
`terraform.tfvars`