### PR TITLE
Set map_public_ip_on_launch to true

### DIFF
--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -29,17 +29,19 @@ locals {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "2.24.0"
+  version = "2.33.0"
 
-  create_vpc             = var.enable_vpc
-  name                   = var.name
-  azs                    = local.az_placement
-  cidr                   = var.vpc_cidr
-  enable_nat_gateway     = var.enable_nat_gateway
-  single_nat_gateway     = var.single_nat_gateway
-  one_nat_gateway_per_az = var.one_nat_gateway_per_az
-  private_subnets        = local.private_subnets
-  public_subnets         = local.public_subnets
+  create_vpc              = var.enable_vpc
+  name                    = var.name
+  azs                     = local.az_placement
+  cidr                    = var.vpc_cidr
+  enable_nat_gateway      = var.enable_nat_gateway
+  single_nat_gateway      = var.single_nat_gateway
+  one_nat_gateway_per_az  = var.one_nat_gateway_per_az
+  private_subnets         = local.private_subnets
+  public_subnets          = local.public_subnets
+  map_public_ip_on_launch = var.map_public_ip_on_launch
+
 
   # DNS
   enable_dns_hostnames = var.vpc_enable_dns_hostnames

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -61,3 +61,6 @@ variable "enable_dynamodb_endpoint" {
   default = true
 }
 
+variable "map_public_ip_on_launch" {
+  default = true
+}


### PR DESCRIPTION
This change is response to https://aws.amazon.com/blogs/containers/upcoming-changes-to-ip-assignment-for-eks-managed-node-groups/ this ensures that if we want to deploy node groups in the public subnet it will associate a public IP by default to the node.

Also bumped the module version