### PR TITLE
Cleanup role creation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -24,7 +24,6 @@ module "users" {
   create_delegated_permissions = var.users["create_delegated_permissions"]
   write_access_files           = var.users["write_access_files"]
   users                        = var.admin_users
-  delegated_account_ids        = var.delegated_account_ids
 }
 
 module "maws" {

--- a/modules/users/main.tf
+++ b/modules/users/main.tf
@@ -6,18 +6,6 @@ locals {
   create_access_keys           = var.create_access_keys ? 1 : 0
   create_delegated_permissions = var.create_delegated_permissions ? 1 : 0
   write_access_files           = var.write_access_files ? 1 : 0
-  delegated_admin_arn = formatlist(
-    "arn:aws:iam::%s:role/itsre-admin",
-    var.delegated_account_ids,
-  )
-  delegated_readonly_arn = formatlist(
-    "arn:aws:iam::%s:role/itsre-readonly",
-    var.delegated_account_ids,
-  )
-  delegated_poweruser_arn = formatlist(
-    "arn:aws:iam::%s:role/itsre-poweruser",
-    var.delegated_account_ids,
-  )
 }
 
 # NOTE: When you switch the paths around the template needs its path
@@ -41,11 +29,11 @@ data "aws_iam_policy_document" "group-sts" {
     sid     = "AllowIndividualUserToAssumeRole"
     actions = ["sts:AssumeRole"]
 
-    resources = flatten([
-      local.delegated_admin_arn,
-      local.delegated_readonly_arn,
-      local.delegated_poweruser_arn,
-    ])
+    resources = [
+      "arn:aws:iam::*:role/itsre-admin",
+      "arn:aws:iam::*:role/itsre-readonly",
+      "arn:aws:iam::*:role/itsre-poweruser"
+    ]
 
     condition {
       test     = "Bool"

--- a/modules/users/variables.tf
+++ b/modules/users/variables.tf
@@ -25,8 +25,3 @@ variable "users" {
 variable "iam_path_prefix" {
   default = "itsre"
 }
-
-variable "delegated_account_ids" {
-  type = list(string)
-}
-

--- a/variables.tf
+++ b/variables.tf
@@ -10,11 +10,6 @@ variable "admin_users" {
   default = ["elim", "eziegenhorn", "kferrando", "sidler", "adelbarrio", "afrank"]
 }
 
-variable "delegated_account_ids" {
-  type    = list(string)
-  default = ["921547910285", "177680776199"]
-}
-
 variable "features" {
   description = "List of features to enable, look at local.tf for full list of valus"
   type        = map(string)


### PR DESCRIPTION
Previously we would list our every account ID to allow our accounts to assume role into other accounts. To simplify this I'm just removing the list and just doing a wildcard for the role so that we don't have to add the delegated role and then create a list separately.