### PR TITLE
Fix deploy module to support tf 0.14

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,5 @@
 provider "aws" {
-  version = "~> 2"
-  region  = var.region
+  region = var.region
 }
 
 data "aws_caller_identity" "current" {

--- a/modules/dns/outputs.tf
+++ b/modules/dns/outputs.tf
@@ -12,3 +12,7 @@ output "master_zone_name" {
   value = element(concat(aws_route53_zone.main.*.name, [""]), 0)
 }
 
+output "delegation_set_id" {
+  value = element(concat(aws_route53_delegation_set.default.*.id, [""]), 0)
+}
+

--- a/modules/dns/versions.tf
+++ b/modules/dns/versions.tf
@@ -1,4 +1,0 @@
-
-terraform {
-  required_version = ">= 0.12"
-}

--- a/modules/policies/versions.tf
+++ b/modules/policies/versions.tf
@@ -1,4 +1,0 @@
-
-terraform {
-  required_version = ">= 0.12"
-}

--- a/modules/users/versions.tf
+++ b/modules/users/versions.tf
@@ -1,4 +1,0 @@
-
-terraform {
-  required_version = ">= 0.12"
-}

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -29,7 +29,7 @@ locals {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "2.44.0"
+  version = "2.64.0"
 
   create_vpc              = var.enable_vpc
   name                    = var.name

--- a/modules/vpc/versions.tf
+++ b/modules/vpc/versions.tf
@@ -1,4 +1,0 @@
-
-terraform {
-  required_version = ">= 0.12"
-}

--- a/versions.tf
+++ b/versions.tf
@@ -1,4 +1,8 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.12.21"
+
+  required_providers {
+    aws = ">= 2.68"
+  }
 }


### PR DESCRIPTION
Sneaked in a vpc upgrade too

Changelog for changes for upstream vpc module can be found here: https://github.com/terraform-aws-modules/terraform-aws-vpc/blob/master/CHANGELOG.md

Diff between tags: https://github.com/terraform-aws-modules/terraform-aws-vpc/compare/v2.44.0...v2.64.0

It doesn't have very big breaking changes from the look of it